### PR TITLE
Ws/bug fix

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -8,6 +8,9 @@
 /// <reference path="../router/message-routes.ts" />
 
 module Prisc {
+    // 本当はURLの中で?imageURI=xxxxxxとしてメッセージングしたいが
+    // too long URL 制限がかかってバグる
+    export var capturedImageURI: string;
     export class Controller {
         private static baseURL = 'asset/html/app.html';
         constructor(public controllerName: string = ""){}
@@ -27,7 +30,7 @@ module Prisc {
         capture(windowId: number, options: chrome.tabs.CaptureVisibleTabOptions) {
             chrome.tabs.captureVisibleTab(windowId, options, (imageURI: string) => {
                 if (Config.get('only-capture')) Controller.downloadWithoutEditing(imageURI);
-                else Controller.openCaptureViewByImageURI(imageURI);
+                else Controller.openCaptureByMessagingBackgroundPage(imageURI);
             });
         }
         private static downloadWithoutEditing(imageURI: string) {
@@ -51,20 +54,25 @@ module Prisc {
             });
             */
         }
-        public static openCaptureViewByImageURI(imageURI: string) {
+        public static openCaptureByMessagingBackgroundPage(imageURI: string) {
             var query = new Util.Query({
-                view: 'Capture',
-                imageURI: imageURI
+                view: 'Capture'
+                // `too long url`
+                // imageURI: imageURI
             });
-            Controller._log_20140412(imageURI);
+            Prisc.capturedImageURI = imageURI;
             Controller.open({
                 url: Controller.baseURL + query.toString()
             });
         }
-        private static _log_20140412(imageURI: string) {
-            console.log("ImageURI", imageURI);
-            console.log("LENGTH?", imageURI.length);
-            window.alert("ImageURI.length\t" + imageURI.length);
+        public static openCaptureViewByMessagingUrl(imageURI: string) {
+            var query = new Util.Query({
+                view: 'Capture',
+                imageURI: imageURI
+            });
+            Controller.open({
+                url: Controller.baseURL + query.toString()
+            });
         }
         public static open(params: chrome.tabs.CreateProperties, callback: (tab: any) => any = (tab: any) => {}) {
             chrome.tabs.create(params, (tab) => {

--- a/src/model/canvas/tools/trim.ts
+++ b/src/model/canvas/tools/trim.ts
@@ -34,7 +34,7 @@ module Prisc {
             this.rollback();
 
             var imageURI = this.getTrimmedImageURI();
-            Controller.openCaptureViewByImageURI(imageURI);
+            Controller.openCaptureViewByMessagingUrl(imageURI);
         }
         private rollback() {
             this.canvas.__context.putImageData(

--- a/src/view/capture/canvas-view.ts
+++ b/src/view/capture/canvas-view.ts
@@ -12,11 +12,21 @@ module Prisc {
         public canvas: Canvas;
         private tpl = new HBSTemplate('capture/canvas.hbs');
         private fileActionTpl = new HBSTemplate('capture/file-action.hbs');
-        constructor(private imageURI: string){
+        constructor(public imageURI: string){
             super({
                 tagName: 'div',
                 className: 'boxy'
             });
+            this.ensureImageURI();
+        }
+        ensureImageURI() {
+            var query = new Util.Query();
+            var imageURIFromQuery = query.toJSON()['imageURI'];
+            if (imageURIFromQuery) {
+                this.imageURI = imageURIFromQuery;
+            } else {
+                this.imageURI = chrome.extension.getBackgroundPage()['Prisc']['capturedImageURI'];
+            }
         }
         events(): Object {
             return {


### PR DESCRIPTION
- #26 URL too long のバグを回避する
  - アイコンクリック時のキャプチャはBackgroundPageにImageURIを保存してViewで取得
  - トリミング時のキャプチャはURLでViewまでメッセージングする
  - Viewでの取得は`ensuerImageURI()`が相当
